### PR TITLE
PR for #85 (Template): Ideate new approach to formatting table/diagram structure in template

### DIFF
--- a/gslab_make/__init__.py
+++ b/gslab_make/__init__.py
@@ -44,7 +44,7 @@ from gslab_make.move_sources import (link_inputs, link_externals,
 from gslab_make.run_program import (run_stata, run_matlab, run_perl, run_python, 
                                     run_jupyter, run_mathematica, run_stat_transfer, 
                                     run_lyx, run_latex, run_r, run_julia, run_sas, 
-                                    run_excel, quit_excel, execute_command, run_module)
+                                    export_excel_tables, quit_excel, execute_command, run_module)
 
 from gslab_make.make_utility import (update_executables, update_external_paths, update_paths, update_internal_paths, copy_output)
 from gslab_make.write_logs import (start_makelog, end_makelog, write_to_makelog,

--- a/gslab_make/__init__.py
+++ b/gslab_make/__init__.py
@@ -44,7 +44,7 @@ from gslab_make.move_sources import (link_inputs, link_externals,
 from gslab_make.run_program import (run_stata, run_matlab, run_perl, run_python, 
                                     run_jupyter, run_mathematica, run_stat_transfer, 
                                     run_lyx, run_latex, run_r, run_julia, run_sas, 
-                                    execute_command, run_module)
+                                    run_excel, execute_command, run_module)
 
 from gslab_make.make_utility import (update_executables, update_external_paths, update_paths, update_internal_paths, copy_output)
 from gslab_make.write_logs import (start_makelog, end_makelog, write_to_makelog,

--- a/gslab_make/__init__.py
+++ b/gslab_make/__init__.py
@@ -44,7 +44,7 @@ from gslab_make.move_sources import (link_inputs, link_externals,
 from gslab_make.run_program import (run_stata, run_matlab, run_perl, run_python, 
                                     run_jupyter, run_mathematica, run_stat_transfer, 
                                     run_lyx, run_latex, run_r, run_julia, run_sas, 
-                                    run_excel, execute_command, run_module)
+                                    run_excel, quit_excel, execute_command, run_module)
 
 from gslab_make.make_utility import (update_executables, update_external_paths, update_paths, update_internal_paths, copy_output)
 from gslab_make.write_logs import (start_makelog, end_makelog, write_to_makelog,

--- a/gslab_make/run_program.py
+++ b/gslab_make/run_program.py
@@ -1099,7 +1099,7 @@ def write_excel_scalars(template, scalar):
     except Exception as e:
         raise RuntimeError(f"Error in `write_excel_scalars`: {e}")
     
-def run_excel(paths, template, scalar, **kwargs):
+def export_excel_tables(paths, template, scalar, **kwargs):
     """.. Convert Excel template file to PDF using Microsoft Excel's native functionality.
     
     Converts Excel document specified by `template` to a PDF file. The resulting PDF
@@ -1157,7 +1157,7 @@ def run_excel(paths, template, scalar, **kwargs):
             'output_dir': 'path/to/output'
         }
         
-        run_excel(PATHS, template = 'tables/skeletons/example_table.xlsx', scalar = 'tables/scalars/example_scalar.xlsx')
+        export_excel_tables(PATHS, template = 'tables/skeletons/example_table.xlsx', scalar = 'tables/scalars/example_scalar.xlsx')
     
     """
     
@@ -1281,7 +1281,7 @@ def run_excel(paths, template, scalar, **kwargs):
         os.replace(temp_pdf_output_path, pdf_output_path)
 
     except Exception as e:
-        error_message = f"Error in `run_excel` for {template}: {e}\n"
+        error_message = f"Error in `export_excel_tables` for {template}: {e}\n"
         if makelog:
             with open(makelog, 'a') as makelog_file:
                 makelog_file.write(error_message)
@@ -1351,7 +1351,7 @@ def quit_excel(paths, **kwargs):
                 raise Exception(f"AppleScript Error: {process.stderr}")
             
     except Exception as e:
-        error_message = f"Error in `run_excel` for {template}: {e}\n"
+        error_message = f"Error in `export_excel_tables` for {template}: {e}\n"
         if makelog:
             with open(makelog, 'a') as makelog_file:
                 makelog_file.write(error_message)
@@ -1493,5 +1493,5 @@ def run_module(root, module, build_script = 'make.py', osname = None, run_all=Tr
 
 __all__ = ['run_stata', 'run_matlab', 'run_perl', 'run_python', 
            'run_jupyter', 'run_mathematica', 'run_stat_transfer', 
-           'run_lyx', 'run_latex', 'run_r', 'run_sas', 'run_excel',
+           'run_lyx', 'run_latex', 'run_r', 'run_sas', 'export_excel_tables',
            'quit_excel', 'execute_command', 'run_module']

--- a/gslab_make/run_program.py
+++ b/gslab_make/run_program.py
@@ -1183,7 +1183,7 @@ def export_excel_tables(paths, template, scalar, **kwargs):
 
         # Populates template skeleton with scalar values.
         if scalar != False:
-            scalar_file_path = os.path.join(script_caller_dir, 'tables/scalars', scalar)
+            scalar_file_path = os.path.join(script_caller_dir, 'input/tables', scalar)
             write_to_makelog(paths, scalar_file_path)
             write_excel_scalars(skeleton_file_path, scalar_file_path)
 

--- a/gslab_make/run_program.py
+++ b/gslab_make/run_program.py
@@ -1105,6 +1105,24 @@ def run_excel(paths, template, scalar, **kwargs):
     Converts Excel document specified by `template` to a PDF file. The resulting PDF
     will be saved in the `output_dir` specified within the `paths` dictionary.
     
+    ------------------------------
+    Instructions for first-time usage on macOS:
+    ------------------------------
+
+    For Mac Users: When first running this script, you must grant Microsoft Excel access to the folder
+    where the Excel files are located and where the PDFs will be saved (i.e. your local
+    repository). This is a one-time setup to allow the script to run without interruptions. You will
+    be notified by a pop-up window whether to grant these permissions. If you select "Yes", you can
+    check the status of permissions with the following steps:
+    
+    1. Open 'System Settings' from the Apple menu or search for it using Spotlight.
+    
+    2. Go to the 'Privacy & Security' tab.
+    
+    3. From the list on the right, choose 'Files and Folders', then navigate to the Microsoft Excel icon.
+    
+    4. In the associated dropdown, you should see the folders that you have granted Microsoft Excel access to.
+
     Parameters
     ----------
     paths : dict
@@ -1230,6 +1248,11 @@ def run_excel(paths, template, scalar, **kwargs):
             if process.returncode != 0:
                 print(f"AppleScript Error: {process.stderr}")
                 raise Exception(f"AppleScript Error: {process.stderr}")
+            
+            temp_files_path = os.path.join(script_caller_dir, 'tables/skeletons')
+            for filename in os.listdir(temp_files_path):
+                if filename.startswith('~$') and filename.endswith('.xlsx'):
+                    os.remove(os.path.join(temp_files_path, filename))
 
         elif osname == 'Windows':
             # Start an instance of Excel


### PR DESCRIPTION
The spirit of this PR runs in parallel to the `template` version [here](https://github.com/gentzkow/template/pull/97).

The purpose of this PR is to extend the `template` architecture to enable native Excel to PDF conversions. See the [issue thread](https://github.com/gentzkow/template/issues/85) for additional details, and in particular https://github.com/gentzkow/template/issues/85#issuecomment-1819927895 for the final proposal of the workflow. The core workhorse function is `export_excel_tables()` in `gslab_make()` (find the development version [here](https://github.com/gslab-econ/gslab_make/tree/8027aad4ab3553440db1f361367171caa94d36ca)).

@jc-cisneros has been assigned as a reviewer. As the purpose of this PR runs in parallel to `template`, I would recommend achieving the desiredatum [here](https://github.com/gentzkow/template/pull/97#issue-2106411691) first. Following this, we should be able to merge directly.

Thanks for the review!